### PR TITLE
FIX: Capture versionId in Submission record on draft creation

### DIFF
--- a/src/LynnWorkflow.php
+++ b/src/LynnWorkflow.php
@@ -92,12 +92,8 @@ class LynnWorkflow extends Plugin
               ->all();
             if (empty($existing_submission)) {
               // Create a submission record for this new draft
-              
-              $version_id = NULL;
-              $latestVersion = Entry::find()->revisionOf($entry_id)->addOrderBy('id DESC')->one();
-              if (!empty($latestVersion)) {
-                $version_id = $latestVersion->versionId;
-              }
+
+              $version_id = $event->source->getCurrentRevision()->id ?? null;
 
               $section_id = $draft->sectionId;
               $type_id = $draft->typeId;


### PR DESCRIPTION
## Fixes

1. versionId never captured in Submission record on draft creation